### PR TITLE
[PAXEXAM-740] Fix NoRouteToHostException RMI issue for forked

### DIFF
--- a/pax-swissbox-framework/src/main/java/org/ops4j/pax/swissbox/framework/RemoteFrameworkImpl.java
+++ b/pax-swissbox-framework/src/main/java/org/ops4j/pax/swissbox/framework/RemoteFrameworkImpl.java
@@ -20,6 +20,7 @@ package org.ops4j.pax.swissbox.framework;
 import java.io.ByteArrayInputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.InetAddress;
 import java.net.URL;
 import java.rmi.AccessException;
 import java.rmi.AlreadyBoundException;
@@ -83,7 +84,8 @@ public class RemoteFrameworkImpl implements RemoteFramework
         String port = System.getProperty( RMI_PORT_KEY, "1099" );
         name = System.getProperty( RMI_NAME_KEY );
         timeout = Long.parseLong( System.getProperty( TIMEOUT_KEY, "10000") );
-        registry = LocateRegistry.getRegistry( Integer.parseInt( port ) );
+        String address = InetAddress.getLoopbackAddress().getHostAddress();
+        registry = LocateRegistry.getRegistry( address, Integer.parseInt( port ) );
         URL location1 = getClass().getProtectionDomain().getCodeSource().getLocation();
         URL location2 = Bundle.class.getProtectionDomain().getCodeSource().getLocation();
         URL location3 = ServiceLookup.class.getProtectionDomain().getCodeSource().getLocation();
@@ -110,7 +112,7 @@ public class RemoteFrameworkImpl implements RemoteFramework
         {
             framework.waitForStop(timeout);
         }
-        catch (InterruptedException exc) 
+        catch (InterruptedException exc)
         {
             LOG.severe("framework did not stop within timeout");
         }


### PR DESCRIPTION
These changes are required to fix [PAXEXAM-740](https://ops4j1.jira.com/browse/PAXEXAM-740) for the forked [Pax Exam in change 60](https://github.com/ops4j/org.ops4j.pax.exam2/pull/60); Pax Swissbox would have to be released at 1.8.3, and Pax Exam's dependency to Pax Swissbox then bumped from 1.8.2 to 1.8.3. (The Karaf container does not require these fixes.)

see also
http://blog2.vorburger.ch/2017/04/java-local-rmi-using-jdks-inetaddress.html