### PR TITLE
Updated dependency towards bndlib

### DIFF
--- a/pax-swissbox-bnd/pom.xml
+++ b/pax-swissbox-bnd/pom.xml
@@ -37,15 +37,9 @@
         <!-- Compile dependencies (transitive) -->
         <dependency>
             <groupId>biz.aQute.bnd</groupId>
-            <artifactId>bndlib</artifactId>
-            <version>2.4.0</version>
+            <artifactId>biz.aQute.bndlib</artifactId>
+            <version>4.1.0</version>
             <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.osgi</groupId>
-                    <artifactId>org.osgi.core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.ops4j.base</groupId>


### PR DESCRIPTION
Updated pax-swissbox-bnd's dependency towards bndlib. The version used (2.4.0) was using an older artifact identification (biz.aQute.bnd:bndlib) which is no longer used by the bnd project.